### PR TITLE
Update ssh string

### DIFF
--- a/device/device.py
+++ b/device/device.py
@@ -1,3 +1,4 @@
+"""Functions related to pulling media from a device."""
 import os
 import sys
 from configparser import NoOptionError, NoSectionError
@@ -6,7 +7,6 @@ import click
 from gevent import joinall
 from logbook import Logger, StreamHandler
 from pssh.clients import ParallelSSHClient, SSHClient
-from pssh.utils import load_private_key
 
 StreamHandler(sys.stdout).push_application()
 logger = Logger(__name__)
@@ -66,14 +66,14 @@ def get_pssh_client(host, private_key_path, single_copy=False, port=8022, user='
         return SSHClient(
             host,
             port=port,
-            pkey=load_private_key(private_key_path),
+            pkey=private_key_path,
             user=user
         )
 
     return ParallelSSHClient(
         host,
         port=port,
-        pkey=load_private_key(private_key_path),
+        pkey=private_key_path,
         user=user
     )
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_requirements(file):
     return [str(ir.req) for ir in requirements if not None]
 
 setup(
-    name='workflow_widgets',
+    name='speargun',
     version=get_version(),
     packages=find_packages(),
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
The new version of `parallel-ssh`, the ssh key is now passed as a
string.

Also update the module docstring.